### PR TITLE
Fix: wrong source directory path returned from ProjectUtils.getSrcDirectories()

### DIFF
--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/utils/ProjectUtils.java
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/utils/ProjectUtils.java
@@ -7,6 +7,8 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
@@ -67,13 +69,23 @@ public class ProjectUtils {
     @NotNull
     public static List<File> getSrcDirectories(@NotNull IJavaProject javaProject) throws JavaModelException {
         List<File> srcDirectories = new ArrayList<File>();
-        
-        IClasspathEntry[] classpathEntries = javaProject.getRawClasspath();
-        String rootDirectory = javaProject.getProject().getLocation().removeLastSegments(1).toPortableString();
-        for (IClasspathEntry classpathEntry : classpathEntries) {
-            if (classpathEntry.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
-                File file = new File(rootDirectory + classpathEntry.getPath().toPortableString());
-                srcDirectories.add(file);
+
+        IClasspathEntry[] classPathEntries = javaProject.getRawClasspath();
+        IWorkspaceRoot root = javaProject.getProject().getWorkspace().getRoot();
+        for (IClasspathEntry classPathEntry : classPathEntries) {
+            if (classPathEntry.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
+                IPath classPathEntryPath = classPathEntry.getPath();
+                IResource classPathResource = root.findMember(classPathEntryPath);
+                String path;
+                if (classPathResource == null) {
+                    path = classPathEntryPath.toOSString();
+                } else {
+                    path = classPathResource.getLocation().toOSString();
+                }
+                
+                if (!path.isEmpty()) {
+                    srcDirectories.add(new File(path));
+                }
             }
         }
         

--- a/kotlin-eclipse-test-framework/src/org/jetbrains/kotlin/testframework/utils/TestJavaProject.java
+++ b/kotlin-eclipse-test-framework/src/org/jetbrains/kotlin/testframework/utils/TestJavaProject.java
@@ -8,6 +8,8 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
@@ -15,6 +17,7 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -22,7 +25,7 @@ import org.jetbrains.kotlin.model.KotlinNature;
 
 public class TestJavaProject {
 	
-	private final static String SRC_FOLDER = "src";
+	public final static String SRC_FOLDER = "src";
 	
 	private IProject project;
 	private IJavaProject javaProject;
@@ -30,15 +33,29 @@ public class TestJavaProject {
 	private IPackageFragmentRoot sourceFolder;
 	
 	public TestJavaProject(String projectName) {
-		project = createProject(projectName);	
+		this(projectName, null);	
+	}	
+
+	public TestJavaProject(String projectName, String location) {
+		project = createProject(projectName, location);	
 	}
-	
-	private IProject createProject(String projectName) {
-		project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+
+	private IProject createProject(String projectName, String location) {
+		
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IWorkspaceRoot workspaceRoot = workspace.getRoot();
+		IProjectDescription projectDescription = workspace.newProjectDescription(projectName);
+		if (location != null) {
+			IPath rootPath = workspaceRoot.getLocation();
+			IPath locationPath = rootPath.append(location);
+			projectDescription.setLocation(locationPath);
+		}
+		
+		project = workspaceRoot.getProject(projectName);
 		try {
 			boolean projectExists = project.exists();
 			if (!projectExists) {
-				project.create(null);
+				project.create(projectDescription, null);
 			}
 			project.open(null);
 			
@@ -117,6 +134,10 @@ public class TestJavaProject {
 		}
 		
 		return folder;
+	}
+	
+	public IJavaProject getJavaProject() {
+		return javaProject;
 	}
 	
 	private void addSystemLibraries() throws JavaModelException {

--- a/kotlin-eclipse-ui-test/META-INF/MANIFEST.MF
+++ b/kotlin-eclipse-ui-test/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.jetbrains.kotlin.ui,
  org.junit,
  org.jetbrains.kotlin.testframework;bundle-version="0.1.0",
- org.eclipse.jdt.ui
+ org.eclipse.jdt.ui,
+ org.jetbrains.kotlin.core
 Import-Package: com.intellij.openapi.util,
  org.eclipse.core.resources,
  org.eclipse.core.runtime;version="3.4.0",

--- a/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/AllTests.java
+++ b/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/AllTests.java
@@ -11,7 +11,9 @@ import org.junit.runners.Suite;
 	KotlinHighlightningTest.class,
 	KotlinBracketInserterTest.class,
 	KotlinOpenDeclarationTest.class,
-	KotlinUnresolvedClassFixTest.class} )
+	KotlinUnresolvedClassFixTest.class,
+	KotlinCustomLocationBugTest.class
+} )
 public class AllTests {
 
 }

--- a/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/KotlinCustomLocationBugTest.java
+++ b/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/KotlinCustomLocationBugTest.java
@@ -1,0 +1,36 @@
+package org.jetbrains.kotlin.ui.tests.editors;
+
+import java.io.File;
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaModelException;
+import org.jetbrains.kotlin.core.utils.ProjectUtils;
+import org.jetbrains.kotlin.testframework.editor.KotlinEditorTestCase;
+import org.jetbrains.kotlin.testframework.utils.TestJavaProject;
+import org.junit.Test;
+
+public class KotlinCustomLocationBugTest extends KotlinEditorTestCase {
+
+	private static final String CUSTOM_LOCATION_TEST_PROJECT_NAME = "Test Project";
+	private static final String CUSTOM_LOCATION_TEST_PROJECT_LOCATION = "custom_location/custom_test_project";
+
+	@Test
+	public void testGetSrcDirectories() throws JavaModelException {
+		TestJavaProject testProject = new TestJavaProject(CUSTOM_LOCATION_TEST_PROJECT_NAME, CUSTOM_LOCATION_TEST_PROJECT_LOCATION);
+		
+		IJavaProject javaProject = testProject.getJavaProject();
+		List<File> files =  ProjectUtils.getSrcDirectories(javaProject);
+	
+		IPath workspaceRootPath = ResourcesPlugin.getWorkspace().getRoot().getLocation();
+		IPath expectedSourcePath = workspaceRootPath.append(CUSTOM_LOCATION_TEST_PROJECT_LOCATION).append(TestJavaProject.SRC_FOLDER);
+		
+		Assert.assertEquals(1, files.size());
+		Assert.assertEquals(expectedSourcePath.toFile(), files.get(0));
+	}
+	
+}


### PR DESCRIPTION
ProjectUtils.getSrcDirectories() may return wrong path(s) in case project directory name doesn't match project name.

Note regarding https://github.com/Maccimo/kotlin-eclipse/commit/cb1e020c8c3e265750a3d2c7998907f7e5d6861d#kotlin-eclipse-core-src-org-jetbrains-kotlin-core-utils-projectutils-java-P29 :

In theory classPathResource  may become null in case classpath entry being examined has an absolute path.
Though UI allow entering absolute paths only in aliased form (Java Build Path &rArr; Link Source), i'm unsure we should ignore this case.
