### PR TITLE
Enforce Team (vcs) support to think that kotlin sources is text files, not binary.

### DIFF
--- a/kotlin-eclipse-core/plugin.xml
+++ b/kotlin-eclipse-core/plugin.xml
@@ -20,5 +20,8 @@
          </run>
       </runtime>
    </extension>
+   <extension point="org.eclipse.team.core.fileTypes">
+      <fileTypes extension="kt" type="text"/>
+   </extension>
 
 </plugin>


### PR DESCRIPTION
Minor priority.
