### PR TITLE
Disable "Psi Visualization" command outside KotlinEditor context.

### DIFF
--- a/kotlin-eclipse-ui-test/META-INF/MANIFEST.MF
+++ b/kotlin-eclipse-ui-test/META-INF/MANIFEST.MF
@@ -14,7 +14,9 @@ Require-Bundle: org.jetbrains.kotlin.bundled-compiler,
  org.aspectj.runtime,
  org.aspectj.weaver,
  org.eclipse.equinox.weaving.aspectj,
- org.jetbrains.kotlin.aspects
+ org.jetbrains.kotlin.aspects,
+ org.eclipse.core.commands,
+ org.eclipse.ui.workbench
 Import-Package: com.intellij.openapi.util,
  com.intellij.openapi.util.io,
  com.intellij.util.containers,

--- a/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/CommandTestCase.java
+++ b/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/CommandTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2000-2014 JetBrains s.r.o.
+ * Copyright 2000-2015 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,21 @@
  *******************************************************************************/
 package org.jetbrains.kotlin.ui.tests.editors;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.eclipse.core.commands.Command;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.commands.ICommandService;
+import org.junit.Assert;
+import org.jetbrains.kotlin.testframework.editor.KotlinEditorTestCase;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( { 
-    KotlinEditorBaseTest.class, 
-    KotlinAutoIndenterTest.class,
-    KotlinAnalyzerInIDETest.class,
-    KotlinHighlightingTest.class,
-    KotlinBracketInserterTest.class,
-    KotlinOpenDeclarationTest.class,
-    KotlinFormatActionTest.class,
-    KotlinCustomLocationBugTest.class,
-    PsiVisualizationCommandTest.class
-} )
-public class AllTests {
+public class CommandTestCase extends KotlinEditorTestCase {
+
+	public static void assertCommandEnabled(String commandId, boolean isEnabled) {
+		IWorkbenchWindow workbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		ICommandService commandService = (ICommandService) workbenchWindow.getService(ICommandService.class);
+		Command command = commandService.getCommand(commandId);		
+
+		Assert.assertEquals(isEnabled, command.isEnabled());
+	}
 
 }

--- a/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/PsiVisualizationCommandTest.java
+++ b/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/PsiVisualizationCommandTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright 2000-2015 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *******************************************************************************/
+package org.jetbrains.kotlin.ui.tests.editors;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.jetbrains.kotlin.testframework.editor.TextEditorTest;
+import org.jetbrains.kotlin.testframework.utils.EditorTestUtils;
+import org.junit.Test;
+
+public class PsiVisualizationCommandTest extends CommandTestCase {
+
+	public static final String COMMAND_ID_PSI_VISUALIZATION = "org.jetbrains.kotlin.psi.visualization";	
+
+	@Test
+	public void testPsiVisualizationCommand_case01() {
+		assertCommandEnabled(COMMAND_ID_PSI_VISUALIZATION, false);
+	}
+
+	@Test
+	public void testPsiVisualizationCommand_case02() {
+		configureEditor("Test.kt", "// Lorem ipsum");
+
+		assertCommandEnabled(COMMAND_ID_PSI_VISUALIZATION, true);
+	}
+
+	@Test
+	public void testPsiVisualizationCommand_case03() throws CoreException {
+		TextEditorTest testEditor = new TextEditorTest();
+
+		IFile file = testEditor.getTestJavaProject().createSourceFile(
+			TextEditorTest.TEST_PACKAGE_NAME, "Test.java", "// Lorem ipsum"
+		);
+		EditorTestUtils.openInEditor(file);
+
+		assertCommandEnabled(COMMAND_ID_PSI_VISUALIZATION, false);
+	}
+
+}

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/psi/visualization/PsiVisualization.java
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/psi/visualization/PsiVisualization.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2000-2014 JetBrains s.r.o.
+ * Copyright 2000-2015 JetBrains s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.ISources;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.jetbrains.kotlin.core.log.KotlinLogger;
 import org.jetbrains.kotlin.eclipse.ui.utils.EditorUtil;
@@ -31,12 +33,14 @@ public class PsiVisualization extends AbstractHandler {
     @Override
     public Object execute(ExecutionEvent event) throws ExecutionException {
         Shell shell = HandlerUtil.getActiveShell(event);
-        KotlinEditor editor = (KotlinEditor) HandlerUtil.getActiveEditor(event);
+        IEditorPart editor = HandlerUtil.getActiveEditor(event);
+
+        assert editor instanceof KotlinEditor : "Unsupported editor class: " + ((editor == null)?"NULL":editor.getClass().getName());
         
         IFile file = EditorUtil.getFile(editor);
         
         if (file != null) {
-            String sourceCode = EditorUtil.getSourceCode(editor);
+            String sourceCode = EditorUtil.getSourceCode((KotlinEditor) editor);
 
             new VisualizationPage(shell, sourceCode, file).open();
         } else {
@@ -44,6 +48,13 @@ public class PsiVisualization extends AbstractHandler {
         }
         
         return null;
+    }
+
+    @Override
+    public void setEnabled(Object evaluationContext) {
+        Object editorObject = HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_EDITOR_NAME);
+
+        setBaseEnabled(editorObject instanceof KotlinEditor);
     }
 
 }


### PR DESCRIPTION
The "Psi Visualization" command assume active editor is KotlinEditor but can be called in custom context via "Quick Access".