### PR TITLE
Non blocking mark occurences operation

### DIFF
--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/kotlinModelUtils.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/kotlinModelUtils.kt
@@ -75,7 +75,7 @@ fun isConfigurationMissing(project: IProject): Boolean {
     }
 }
 
-inline fun runJob(name: String, priority: Int = Job.LONG, crossinline action: (IProgressMonitor) -> IStatus) {
+inline fun runJob(name: String, priority: Int = Job.LONG, crossinline action: (IProgressMonitor) -> IStatus): Job {
     val job = object : Job(name) {
         override fun run(monitor: IProgressMonitor): IStatus {
             return action(monitor)
@@ -84,4 +84,5 @@ inline fun runJob(name: String, priority: Int = Job.LONG, crossinline action: (I
     
     job.setPriority(priority)
     job.schedule()
+	return job
 }

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/kotlinModelUtils.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/kotlinModelUtils.kt
@@ -75,7 +75,7 @@ fun isConfigurationMissing(project: IProject): Boolean {
     }
 }
 
-inline fun runJob(name: String, priority: Int = Job.LONG, crossinline action: (IProgressMonitor) -> IStatus): Job {
+inline fun runJob(name: String, priority: Int = Job.LONG, delay: Long = 0, crossinline action: (IProgressMonitor) -> IStatus): Job {
     val job = object : Job(name) {
         override fun run(monitor: IProgressMonitor): IStatus {
             return action(monitor)
@@ -83,6 +83,6 @@ inline fun runJob(name: String, priority: Int = Job.LONG, crossinline action: (I
     }
     
     job.setPriority(priority)
-    job.schedule()
+    job.schedule(delay)
 	return job
 }


### PR DESCRIPTION
I have made some changes to 'Mark occurences' task behaviour, 

I am aware that these changes are not ideal, but the plugin was nearly unusable without them, every change in editor produced number of backround tasks. and even single task blocked eclipse more than necessary.

I have removed synchronized section in KotlinPsiManager, I think that in this case responsivity is primary goal and I have used SynchronizedMaps to synchronize access to cached projects and kotlin files to improve performance, I am using this modified plugin for several months without serious problems and without blocking events like 'Update occurance annotations' backround task.

I am not very experienced in opensource projects, so please forgive me if I have done something wrong, I will gladly learn how to do it properly.

https://discuss.kotlinlang.org/t/extremely-poor-performance-of-the-kotlin-plugin-for-eclipse/3397