### PR TITLE
 KT-11981 Eclipse: add human-readable info about problem location to error marker

### DIFF
--- a/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/markers/AllTests.java
+++ b/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/markers/AllTests.java
@@ -21,7 +21,7 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses( { 
-    KotlinParsingMarkersTest.class
+    KotlinParsingMarkersTest.class, MarkerAttributesTest.class
 } )
 public class AllTests {
     

--- a/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/markers/KotlinParsingMarkersTestCase.java
+++ b/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/markers/KotlinParsingMarkersTestCase.java
@@ -41,6 +41,18 @@ public abstract class KotlinParsingMarkersTestCase extends KotlinEditorWithAfter
     
     @Override
     protected void performTest(String fileText, String expected) {
+
+        try{
+            IMarker[] markers = generateAndGetProblemMarkers(fileText);
+            String actual = insertTagsForErrors(EditorUtil.getSourceCode(getTestEditor().getEditor()), markers);
+            
+            Assert.assertEquals(expected, actual);
+        } catch (CoreException e) {
+            KotlinLogger.logAndThrow(e);
+        }
+    }
+
+    protected IMarker[] generateAndGetProblemMarkers(String fileText) throws CoreException {
         IFile file = getTestEditor().getEditingFile();
         
         Character typedCharacter = TypingUtils.typedCharacter(fileText);
@@ -53,14 +65,7 @@ public abstract class KotlinParsingMarkersTestCase extends KotlinEditorWithAfter
             AnnotationManager.INSTANCE.addProblemMarker(annotation, file);
         }
         
-        try {
-            IMarker[] markers = getTestEditor().getEditingFile().findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
-            String actual = insertTagsForErrors(EditorUtil.getSourceCode(getTestEditor().getEditor()), markers);
-            
-            Assert.assertEquals(expected, actual);
-        } catch (CoreException e) {
-            KotlinLogger.logAndThrow(e);
-        }
+        return getTestEditor().getEditingFile().findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);   
     }
     
     private static String insertTagsForErrors(String fileText, IMarker[] markers) throws CoreException {

--- a/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/markers/MarkerAttributesTest.java
+++ b/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/markers/MarkerAttributesTest.java
@@ -1,0 +1,61 @@
+package org.jetbrains.kotlin.ui.tests.editors.markers;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.jetbrains.kotlin.core.builder.KotlinPsiManager;
+import org.jetbrains.kotlin.core.log.KotlinLogger;
+import org.jetbrains.kotlin.eclipse.ui.utils.EditorUtil;
+import org.jetbrains.kotlin.testframework.utils.TypingUtils;
+import org.jetbrains.kotlin.ui.editors.annotations.AnnotationManager;
+import org.jetbrains.kotlin.ui.editors.annotations.DiagnosticAnnotation;
+import org.jetbrains.kotlin.ui.editors.annotations.DiagnosticAnnotationUtil;
+import org.junit.Test;
+
+public class MarkerAttributesTest extends KotlinParsingMarkersTestCase {
+    @Override
+    protected String getTestDataRelativePath() {
+        return "markers/parsing";
+    }
+
+    @Override
+    protected void performTest(String fileText, String expected) {
+        IFile file = getTestEditor().getEditingFile();
+        
+        Character typedCharacter = TypingUtils.typedCharacter(fileText);
+        if (typedCharacter != null) {
+            getTestEditor().type(typedCharacter);
+        }
+        
+        KotlinPsiManager.getKotlinFileIfExist(file, EditorUtil.getSourceCode(getTestEditor().getEditor())); // We should update file because problem markers are adding manually
+        for (DiagnosticAnnotation annotation : DiagnosticAnnotationUtil.INSTANCE.createParsingDiagnosticAnnotations(file)) {
+            AnnotationManager.INSTANCE.addProblemMarker(annotation, file);
+        }
+        
+        try {
+            IMarker[] markers = getTestEditor().getEditingFile().findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
+
+            Arrays.asList(markers).forEach(marker -> {
+                try {
+                    assertThat(marker.getAttribute(IMarker.LOCATION), equalTo("line 3"));
+                    assertThat(marker.getAttribute(IMarker.LINE_NUMBER), equalTo(3));
+                } catch (CoreException e) {
+                    KotlinLogger.logAndThrow(e);
+                }
+            });
+        } catch (CoreException e) {
+            KotlinLogger.logAndThrow(e);
+        }
+    }
+    
+    @Test
+    public void missingClosingBraceErrorTest() {
+        doAutoTest();
+    }
+}

--- a/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/markers/MarkerAttributesTest.java
+++ b/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/ui/tests/editors/markers/MarkerAttributesTest.java
@@ -1,21 +1,27 @@
+/*******************************************************************************
+ * Copyright 2000-2014 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *******************************************************************************/
 package org.jetbrains.kotlin.ui.tests.editors.markers;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.util.Arrays;
-
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
-import org.jetbrains.kotlin.core.builder.KotlinPsiManager;
 import org.jetbrains.kotlin.core.log.KotlinLogger;
-import org.jetbrains.kotlin.eclipse.ui.utils.EditorUtil;
-import org.jetbrains.kotlin.testframework.utils.TypingUtils;
-import org.jetbrains.kotlin.ui.editors.annotations.AnnotationManager;
-import org.jetbrains.kotlin.ui.editors.annotations.DiagnosticAnnotation;
-import org.jetbrains.kotlin.ui.editors.annotations.DiagnosticAnnotationUtil;
 import org.junit.Test;
 
 public class MarkerAttributesTest extends KotlinParsingMarkersTestCase {
@@ -23,32 +29,16 @@ public class MarkerAttributesTest extends KotlinParsingMarkersTestCase {
     protected String getTestDataRelativePath() {
         return "markers/parsing";
     }
-
+    
     @Override
     protected void performTest(String fileText, String expected) {
-        IFile file = getTestEditor().getEditingFile();
-        
-        Character typedCharacter = TypingUtils.typedCharacter(fileText);
-        if (typedCharacter != null) {
-            getTestEditor().type(typedCharacter);
-        }
-        
-        KotlinPsiManager.getKotlinFileIfExist(file, EditorUtil.getSourceCode(getTestEditor().getEditor())); // We should update file because problem markers are adding manually
-        for (DiagnosticAnnotation annotation : DiagnosticAnnotationUtil.INSTANCE.createParsingDiagnosticAnnotations(file)) {
-            AnnotationManager.INSTANCE.addProblemMarker(annotation, file);
-        }
-        
         try {
-            IMarker[] markers = getTestEditor().getEditingFile().findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
-
-            Arrays.asList(markers).forEach(marker -> {
-                try {
-                    assertThat(marker.getAttribute(IMarker.LOCATION), equalTo("line 3"));
-                    assertThat(marker.getAttribute(IMarker.LINE_NUMBER), equalTo(3));
-                } catch (CoreException e) {
-                    KotlinLogger.logAndThrow(e);
-                }
-            });
+            IMarker[] markers = generateAndGetProblemMarkers(fileText);
+            
+            for (IMarker marker : markers) {
+                assertThat(marker.getAttribute(IMarker.LOCATION), equalTo("line 3"));
+                assertThat(marker.getAttribute(IMarker.LINE_NUMBER), equalTo(3));
+            }
         } catch (CoreException e) {
             KotlinLogger.logAndThrow(e);
         }

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/annotations/AnnotationManager.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/annotations/AnnotationManager.kt
@@ -82,8 +82,8 @@ public object AnnotationManager {
             setAttribute(IMarker.SEVERITY, annotation.markerSeverity)
             setAttribute(IMarker.CHAR_START, annotation.offset)
             setAttribute(IMarker.CHAR_END, annotation.endOffset)
-			setAttribute(IMarker.LOCATION, "line ${annotation.line}")
-			setAttribute(IMarker.LINE_NUMBER, annotation.line)
+            setAttribute(IMarker.LOCATION, "line ${annotation.line}")
+            setAttribute(IMarker.LINE_NUMBER, annotation.line)
             setAttribute(MARKED_TEXT, annotation.markedText)
             
             val diagnostic = annotation.diagnostic

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/annotations/AnnotationManager.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/annotations/AnnotationManager.kt
@@ -82,6 +82,8 @@ public object AnnotationManager {
             setAttribute(IMarker.SEVERITY, annotation.markerSeverity)
             setAttribute(IMarker.CHAR_START, annotation.offset)
             setAttribute(IMarker.CHAR_END, annotation.endOffset)
+			setAttribute(IMarker.LOCATION, "line " + (annotation.line + 1))
+			setAttribute(IMarker.LINE_NUMBER, annotation.line + 1)
             setAttribute(MARKED_TEXT, annotation.markedText)
             
             val diagnostic = annotation.diagnostic

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/annotations/AnnotationManager.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/annotations/AnnotationManager.kt
@@ -82,8 +82,8 @@ public object AnnotationManager {
             setAttribute(IMarker.SEVERITY, annotation.markerSeverity)
             setAttribute(IMarker.CHAR_START, annotation.offset)
             setAttribute(IMarker.CHAR_END, annotation.endOffset)
-			setAttribute(IMarker.LOCATION, "line " + (annotation.line + 1))
-			setAttribute(IMarker.LINE_NUMBER, annotation.line + 1)
+			setAttribute(IMarker.LOCATION, "line ${annotation.line}")
+			setAttribute(IMarker.LINE_NUMBER, annotation.line)
             setAttribute(MARKED_TEXT, annotation.markedText)
             
             val diagnostic = annotation.diagnostic

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/annotations/DiagnosticAnnotation.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/annotations/DiagnosticAnnotation.kt
@@ -26,6 +26,7 @@ import org.eclipse.jdt.core.ICompilationUnit
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 
 class DiagnosticAnnotation(
+		val line: Int,
         val offset: Int,
         val length: Int,
         val annotationType: String, 

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/annotations/DiagnosticAnnotationUtil.java
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/annotations/DiagnosticAnnotationUtil.java
@@ -81,12 +81,8 @@ public class DiagnosticAnnotationUtil {
                 annotations.put(curFile, new ArrayList<DiagnosticAnnotation>());
             }
             
-            try {
-                DiagnosticAnnotation annotation = createKotlinAnnotation(diagnostic, curFile);
-                annotations.get(curFile).add(annotation);
-            } catch (BadLocationException e) {
-                KotlinLogger.logAndThrow(e);
-            }
+            DiagnosticAnnotation annotation = createKotlinAnnotation(diagnostic, curFile);
+            annotations.get(curFile).add(annotation);
         }
         
         return annotations;
@@ -146,14 +142,21 @@ public class DiagnosticAnnotationUtil {
     }
     
     @NotNull
-    private DiagnosticAnnotation createKotlinAnnotation(@NotNull Diagnostic diagnostic, @NotNull IFile file) throws BadLocationException {
+    private DiagnosticAnnotation createKotlinAnnotation(@NotNull Diagnostic diagnostic, @NotNull IFile file) {
         TextRange range = diagnostic.getTextRanges().get(0);
         
         IDocument document = EditorUtil.getDocument(file);
         int offset = LineEndUtil.convertLfToDocumentOffset(diagnostic.getPsiFile().getText(), 
                 range.getStartOffset(), document);
         
-        return new DiagnosticAnnotation(document.getLineOfOffset(offset),
+        int lineOfOffset = 0;
+        try {
+            lineOfOffset = document.getLineOfOffset(offset);
+        } catch (BadLocationException e) {
+            KotlinLogger.logAndThrow(e);
+        }
+        
+        return new DiagnosticAnnotation(lineOfOffset,
                 offset,
                 range.getLength(),
                 getAnnotationType(diagnostic.getSeverity()), 

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/annotations/DiagnosticAnnotationUtil.java
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/annotations/DiagnosticAnnotationUtil.java
@@ -29,6 +29,8 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
@@ -79,8 +81,12 @@ public class DiagnosticAnnotationUtil {
                 annotations.put(curFile, new ArrayList<DiagnosticAnnotation>());
             }
             
-            DiagnosticAnnotation annotation = createKotlinAnnotation(diagnostic, curFile);
-            annotations.get(curFile).add(annotation);
+            try {
+                DiagnosticAnnotation annotation = createKotlinAnnotation(diagnostic, curFile);
+                annotations.get(curFile).add(annotation);
+            } catch (BadLocationException e) {
+                KotlinLogger.logAndThrow(e);
+            }
         }
         
         return annotations;
@@ -101,14 +107,18 @@ public class DiagnosticAnnotationUtil {
         KtFile jetFile = KotlinPsiManager.INSTANCE.getParsedFile(file);
         List<DiagnosticAnnotation> result = new ArrayList<DiagnosticAnnotation>();
         for (PsiErrorElement syntaxError : AnalyzingUtils.getSyntaxErrorRanges(jetFile)) {
-            result.add(createKotlinAnnotation(syntaxError, file));
+            try {
+                result.add(createKotlinAnnotation(syntaxError, file));
+            } catch (BadLocationException e) {
+                KotlinLogger.logAndThrow(e);
+            }
         }
         
         return result;
     }
     
     @NotNull
-    private DiagnosticAnnotation createKotlinAnnotation(@NotNull PsiErrorElement psiErrorElement, @NotNull IFile file) {
+    private DiagnosticAnnotation createKotlinAnnotation(@NotNull PsiErrorElement psiErrorElement, @NotNull IFile file) throws BadLocationException {
         PsiFile psiFile = psiErrorElement.getContainingFile();
         
         TextRange range = psiErrorElement.getTextRange();
@@ -122,8 +132,12 @@ public class DiagnosticAnnotationUtil {
             markedText = psiFile.getText().substring(startOffset, startOffset + length);
         }
         
+        IDocument document = EditorUtil.getDocument(file);
+        int offset = LineEndUtil.convertLfToDocumentOffset(psiFile.getText(), startOffset, document);
+        
         return new DiagnosticAnnotation(
-                LineEndUtil.convertLfToDocumentOffset(psiFile.getText(), startOffset, EditorUtil.getDocument(file)),
+                document.getLineOfOffset(offset),
+                offset,
                 length,
                 AnnotationManager.ANNOTATION_ERROR_TYPE,
                 psiErrorElement.getErrorDescription(),
@@ -132,11 +146,15 @@ public class DiagnosticAnnotationUtil {
     }
     
     @NotNull
-    private DiagnosticAnnotation createKotlinAnnotation(@NotNull Diagnostic diagnostic, @NotNull IFile file) {
+    private DiagnosticAnnotation createKotlinAnnotation(@NotNull Diagnostic diagnostic, @NotNull IFile file) throws BadLocationException {
         TextRange range = diagnostic.getTextRanges().get(0);
-        return new DiagnosticAnnotation(
-                LineEndUtil.convertLfToDocumentOffset(diagnostic.getPsiFile().getText(), 
-                        range.getStartOffset(), EditorUtil.getDocument(file)),
+        
+        IDocument document = EditorUtil.getDocument(file);
+        int offset = LineEndUtil.convertLfToDocumentOffset(diagnostic.getPsiFile().getText(), 
+                range.getStartOffset(), document);
+        
+        return new DiagnosticAnnotation(document.getLineOfOffset(offset),
+                offset,
                 range.getLength(),
                 getAnnotationType(diagnostic.getSeverity()), 
                 DefaultErrorMessages.render(diagnostic),


### PR DESCRIPTION
 KT-11981 Eclipse: add human-readable info about problem location to error marker

Change-Id: Ic1e02b3db032b20b236abc0f56fde9e2c84b215c
Signed-off-by: Simon Scholz <simon.scholz@vogella.com>