### PR TITLE
KT-14095 Eclipse: Outline view could show implicit types too

### DIFF
--- a/kotlin-eclipse-ui/plugin.xml
+++ b/kotlin-eclipse-ui/plugin.xml
@@ -104,6 +104,29 @@
       </wizard>
    </extension>
    <extension
+         point="org.eclipse.ui.editorActions">
+      <editorContribution
+            id="org.jetbrains.kotlin.ui.debug.KotlinFileEditor.BreakpointRulerActions"
+            targetID="org.jetbrains.kotlin.ui.editors.KotlinFileEditor">
+         <action
+               actionID="RulerDoubleClick"
+               class="org.eclipse.debug.ui.actions.RulerToggleBreakpointActionDelegate"
+               id="org.jetbrains.kotlin.ui.debug.actions.ManageBreakpointRulerAction"
+               label="Toggle &amp;Breakpoint">
+         </action>
+      </editorContribution>
+      <editorContribution
+            id="org.jetbrains.kotlin.ui.debug.KotlinClassFileEditor.BreakpointRulerActions"
+            targetID="org.jetbrains.kotlin.ui.editors.KotlinClassFileEditor">
+         <action
+               actionID="RulerDoubleClick"
+               class="org.eclipse.debug.ui.actions.RulerToggleBreakpointActionDelegate"
+               id="org.jetbrains.kotlin.ui.debug.actions.ManageBreakpointRulerAction"
+               label="Toggle &amp;Breakpoint">
+         </action>
+      </editorContribution>
+   </extension>
+   <extension
          point="org.eclipse.ui.perspectiveExtensions">
       <perspectiveExtension
             targetID="org.eclipse.jdt.ui.JavaPerspective">

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/outline/PsiLabelProvider.java
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/outline/PsiLabelProvider.java
@@ -22,14 +22,19 @@ import org.eclipse.jdt.ui.ISharedImages;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.swt.graphics.Image;
+import org.jetbrains.kotlin.core.model.KotlinAnalysisFileCache;
+import org.jetbrains.kotlin.descriptors.CallableDescriptor;
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor;
 import org.jetbrains.kotlin.psi.KtClass;
 import org.jetbrains.kotlin.psi.KtClassInitializer;
 import org.jetbrains.kotlin.psi.KtElement;
+import org.jetbrains.kotlin.psi.KtFile;
 import org.jetbrains.kotlin.psi.KtFunction;
 import org.jetbrains.kotlin.psi.KtPackageDirective;
 import org.jetbrains.kotlin.psi.KtParameter;
 import org.jetbrains.kotlin.psi.KtProperty;
 import org.jetbrains.kotlin.psi.KtTypeReference;
+import org.jetbrains.kotlin.resolve.BindingContext;
 
 public class PsiLabelProvider extends LabelProvider {
     
@@ -84,6 +89,16 @@ public class PsiLabelProvider extends LabelProvider {
                     text += ":";
                     text += " ";
                     text += ref.getText();
+                } else {
+                    KtFile ktFile = property.getContainingKtFile();
+                    BindingContext bindingContext = KotlinAnalysisFileCache.INSTANCE.getAnalysisResult(ktFile).getAnalysisResult().getBindingContext();
+                    DeclarationDescriptor declarationDescriptor = bindingContext.get(BindingContext.DECLARATION_TO_DESCRIPTOR, property);
+                    if(declarationDescriptor instanceof CallableDescriptor) {
+                        text += " ";
+                        text += ":";
+                        text += " ";
+                        text += ((CallableDescriptor) declarationDescriptor).getReturnType();
+                    }
                 }
             } else if (declaration instanceof KtFunction) {
                 KtFunction function = (KtFunction) declaration;

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/outline/PsiLabelProvider.java
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/editors/outline/PsiLabelProvider.java
@@ -113,8 +113,6 @@ public class PsiLabelProvider extends LabelProvider {
                     KtTypeReference typeReference = parameter.getTypeReference();
                     if (typeReference != null) {
                         text += typeReference.getText();
-                    } else {
-                        text += computeReturnType(function);
                     }
                     text += ", ";
                 }
@@ -126,6 +124,8 @@ public class PsiLabelProvider extends LabelProvider {
                     text += ":";
                     text += " ";
                     text += typeReference.getText();
+                } else {
+                    text += computeReturnType(function);
                 }
             }
         }
@@ -137,10 +137,10 @@ public class PsiLabelProvider extends LabelProvider {
         KtFile ktFile = ktDeclaration.getContainingKtFile();
         BindingContext bindingContext = KotlinAnalysisFileCache.INSTANCE.getAnalysisResult(ktFile).getAnalysisResult().getBindingContext();
         DeclarationDescriptor declarationDescriptor = bindingContext.get(BindingContext.DECLARATION_TO_DESCRIPTOR, ktDeclaration);
-        if(declarationDescriptor instanceof CallableDescriptor) {
+        if (declarationDescriptor instanceof CallableDescriptor) {
             CallableDescriptor callableDescriptor = (CallableDescriptor) declarationDescriptor;
             KotlinType returnType = callableDescriptor.getReturnType();
-            if(returnType != null) {
+            if (returnType != null) {
                 return " : " + DescriptorRenderer.ONLY_NAMES_WITH_SHORT_TYPES.renderType(returnType);
             }
         }


### PR DESCRIPTION
Solved by obtaining a org.jetbrains.kotlin.descriptors.CallableDescriptor from a org.jetbrains.kotlin.resolve.BindingContext

Change-Id: I158d7d44b8f1724f7fbffd4effcd1873747e2404
Signed-off-by: Simon Scholz <simon.scholz@vogella.com>