### PR TITLE
Java kotlin convert

### DIFF
--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/KotlinCommonEnvironment.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/KotlinCommonEnvironment.kt
@@ -27,6 +27,8 @@ import com.intellij.core.JavaCoreApplicationEnvironment
 import com.intellij.core.JavaCoreProjectEnvironment
 import com.intellij.formatting.KotlinLanguageCodeStyleSettingsProvider
 import com.intellij.formatting.KotlinSettingsProvider
+import com.intellij.lang.MetaLanguage
+import com.intellij.lang.jvm.facade.JvmElementProvider
 import com.intellij.mock.MockProject
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.ServiceManager
@@ -36,6 +38,7 @@ import com.intellij.openapi.extensions.ExtensionsArea
 import com.intellij.openapi.fileTypes.PlainTextFileType
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.JavaModuleSystem
 import com.intellij.psi.PsiElementFinder
 import com.intellij.psi.PsiManager
 import com.intellij.psi.augment.PsiAugmentProvider
@@ -43,20 +46,29 @@ import com.intellij.psi.codeStyle.CodeStyleManager
 import com.intellij.psi.codeStyle.CodeStyleSettingsProvider
 import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
 import com.intellij.psi.compiled.ClassFileDecompilers
+import com.intellij.psi.impl.PsiElementFinderImpl
 import com.intellij.psi.impl.PsiTreeChangePreprocessor
 import com.intellij.psi.impl.compiled.ClsCustomNavigationPolicy
 import com.intellij.psi.impl.file.impl.JavaFileManager
 import org.eclipse.core.runtime.IPath
 import org.jetbrains.kotlin.annotation.AnnotationCollectorExtension
+import org.jetbrains.kotlin.asJava.KotlinAsJavaSupport
 import org.jetbrains.kotlin.asJava.LightClassGenerationSupport
+import org.jetbrains.kotlin.asJava.finder.JavaElementFinder
 import org.jetbrains.kotlin.caches.resolve.KotlinCacheService
 import org.jetbrains.kotlin.cli.common.CliModuleVisibilityManagerImpl
+import org.jetbrains.kotlin.cli.common.script.CliScriptDefinitionProvider
+import org.jetbrains.kotlin.cli.common.script.CliScriptDependenciesProvider
+import org.jetbrains.kotlin.cli.jvm.compiler.CliKotlinAsJavaSupport
 import org.jetbrains.kotlin.cli.jvm.compiler.CliLightClassGenerationSupport
-import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.CliModuleAnnotationsResolver
+import org.jetbrains.kotlin.cli.jvm.compiler.CliTraceHolder
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCliJavaFileManagerImpl
 import org.jetbrains.kotlin.cli.jvm.compiler.MockExternalAnnotationsManager
 import org.jetbrains.kotlin.cli.jvm.compiler.MockInferredAnnotationsManager
 import org.jetbrains.kotlin.cli.jvm.index.JavaRoot
+import org.jetbrains.kotlin.cli.jvm.index.JvmDependenciesDynamicCompoundIndex
+import org.jetbrains.kotlin.cli.jvm.index.SingleJavaFileRootsIndex
 import org.jetbrains.kotlin.codegen.extensions.ClassBuilderInterceptorExtension
 import org.jetbrains.kotlin.codegen.extensions.ExpressionCodegenExtension
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
@@ -73,36 +85,18 @@ import org.jetbrains.kotlin.load.kotlin.KotlinBinaryClassCache
 import org.jetbrains.kotlin.load.kotlin.ModuleVisibilityManager
 import org.jetbrains.kotlin.parsing.KotlinParserDefinition
 import org.jetbrains.kotlin.resolve.CodeAnalyzerInitializer
+import org.jetbrains.kotlin.resolve.ModuleAnnotationsResolver
 import org.jetbrains.kotlin.resolve.diagnostics.DiagnosticSuppressor
+import org.jetbrains.kotlin.resolve.jvm.KotlinJavaPsiFacade
 import org.jetbrains.kotlin.resolve.jvm.diagnostics.DefaultErrorMessagesJvm
+import org.jetbrains.kotlin.resolve.jvm.modules.JavaModuleResolver
 import org.jetbrains.kotlin.script.ScriptDefinitionProvider
-import org.jetbrains.kotlin.cli.common.script.CliScriptDefinitionProvider
+import org.jetbrains.kotlin.script.ScriptDependenciesProvider
+import org.jetbrains.kotlin.script.ScriptHelper
+import org.jetbrains.kotlin.script.ScriptHelperImpl
 import java.io.File
 import java.util.LinkedHashSet
 import kotlin.reflect.KClass
-import org.jetbrains.kotlin.cli.common.script.CliScriptDependenciesProvider
-import org.jetbrains.kotlin.script.ScriptDependenciesProvider
-import com.intellij.lang.MetaLanguage
-import org.jetbrains.kotlin.config.JVMConfigurationKeys
-import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.openapi.vfs.StandardFileSystems
-import com.intellij.util.io.URLUtil
-import org.jetbrains.kotlin.resolve.jvm.modules.JavaModuleResolver
-import org.jetbrains.kotlin.asJava.finder.JavaElementFinder
-import com.intellij.psi.impl.PsiElementFinderImpl
-import org.jetbrains.kotlin.script.ScriptHelper
-import org.jetbrains.kotlin.script.ScriptHelperImpl
-import com.intellij.lang.jvm.facade.JvmElementProvider
-import org.jetbrains.kotlin.resolve.ModuleAnnotationsResolver
-import org.jetbrains.kotlin.cli.jvm.compiler.CliModuleAnnotationsResolver
-import org.jetbrains.kotlin.cli.jvm.compiler.CliTraceHolder
-import org.jetbrains.kotlin.cli.jvm.compiler.CliKotlinAsJavaSupport
-import org.jetbrains.kotlin.cli.jvm.index.JvmDependenciesIndexImpl
-import org.jetbrains.kotlin.cli.jvm.index.SingleJavaFileRootsIndex
-import org.jetbrains.kotlin.cli.jvm.index.JvmDependenciesDynamicCompoundIndex
-import org.jetbrains.kotlin.asJava.KotlinAsJavaSupport
-import com.intellij.psi.JavaModuleSystem
-import org.jetbrains.kotlin.resolve.jvm.KotlinJavaPsiFacade
 
 private fun setIdeaIoUseFallback() {
     if (SystemInfo.isWindows) {
@@ -178,18 +172,17 @@ abstract class KotlinCommonEnvironment(disposable: Disposable) {
             }
             
             registerService(JavaModuleResolver::class.java, EclipseKotlinJavaModuleResolver())
-            
+
 			val area = Extensions.getArea(this)
 			area.getExtensionPoint(PsiElementFinder.EP_NAME).registerExtension(JavaElementFinder(this, CliKotlinAsJavaSupport(project, traceHolder)))
 			val javaFileManager = ServiceManager.getService(this, JavaFileManager::class.java)
-			(javaFileManager as KotlinCliJavaFileManagerImpl).initialize(JvmDependenciesDynamicCompoundIndex(), arrayListOf(), SingleJavaFileRootsIndex(arrayListOf()), false)
-            area.getExtensionPoint(PsiElementFinder.EP_NAME).registerExtension(
-                    PsiElementFinderImpl(this, javaFileManager))
-
-            val kotlinAsJavaSupport = CliKotlinAsJavaSupport(this, traceHolder)
-            registerService(KotlinAsJavaSupport::class.java, kotlinAsJavaSupport)
-            area.getExtensionPoint(PsiElementFinder.EP_NAME).registerExtension(JavaElementFinder(this, kotlinAsJavaSupport))
-            registerService(KotlinJavaPsiFacade::class.java, KotlinJavaPsiFacade(this))
+			(javaFileManager as KotlinCliJavaFileManagerImpl)
+					.initialize(JvmDependenciesDynamicCompoundIndex(), arrayListOf(), SingleJavaFileRootsIndex(arrayListOf()), false)
+			area.getExtensionPoint(PsiElementFinder.EP_NAME).registerExtension(PsiElementFinderImpl(this, javaFileManager))
+			val kotlinAsJavaSupport = CliKotlinAsJavaSupport(this, traceHolder)
+			registerService(KotlinAsJavaSupport::class.java, kotlinAsJavaSupport)
+			area.getExtensionPoint(PsiElementFinder.EP_NAME).registerExtension(JavaElementFinder(this, kotlinAsJavaSupport))
+			registerService(KotlinJavaPsiFacade::class.java, KotlinJavaPsiFacade(this))
         }
         
         configuration.put(CommonConfigurationKeys.MODULE_NAME, project.getName())

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/KotlinCommonEnvironment.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/KotlinCommonEnvironment.kt
@@ -97,6 +97,12 @@ import org.jetbrains.kotlin.resolve.ModuleAnnotationsResolver
 import org.jetbrains.kotlin.cli.jvm.compiler.CliModuleAnnotationsResolver
 import org.jetbrains.kotlin.cli.jvm.compiler.CliTraceHolder
 import org.jetbrains.kotlin.cli.jvm.compiler.CliKotlinAsJavaSupport
+import org.jetbrains.kotlin.cli.jvm.index.JvmDependenciesIndexImpl
+import org.jetbrains.kotlin.cli.jvm.index.SingleJavaFileRootsIndex
+import org.jetbrains.kotlin.cli.jvm.index.JvmDependenciesDynamicCompoundIndex
+import org.jetbrains.kotlin.asJava.KotlinAsJavaSupport
+import com.intellij.psi.JavaModuleSystem
+import org.jetbrains.kotlin.resolve.jvm.KotlinJavaPsiFacade
 
 private fun setIdeaIoUseFallback() {
     if (SystemInfo.isWindows) {
@@ -175,8 +181,15 @@ abstract class KotlinCommonEnvironment(disposable: Disposable) {
             
 			val area = Extensions.getArea(this)
 			area.getExtensionPoint(PsiElementFinder.EP_NAME).registerExtension(JavaElementFinder(this, CliKotlinAsJavaSupport(project, traceHolder)))
+			val javaFileManager = ServiceManager.getService(this, JavaFileManager::class.java)
+			(javaFileManager as KotlinCliJavaFileManagerImpl).initialize(JvmDependenciesDynamicCompoundIndex(), arrayListOf(), SingleJavaFileRootsIndex(arrayListOf()), false)
             area.getExtensionPoint(PsiElementFinder.EP_NAME).registerExtension(
-                    PsiElementFinderImpl(this, ServiceManager.getService(this, JavaFileManager::class.java)))
+                    PsiElementFinderImpl(this, javaFileManager))
+
+            val kotlinAsJavaSupport = CliKotlinAsJavaSupport(this, traceHolder)
+            registerService(KotlinAsJavaSupport::class.java, kotlinAsJavaSupport)
+            area.getExtensionPoint(PsiElementFinder.EP_NAME).registerExtension(JavaElementFinder(this, kotlinAsJavaSupport))
+            registerService(KotlinJavaPsiFacade::class.java, KotlinJavaPsiFacade(this))
         }
         
         configuration.put(CommonConfigurationKeys.MODULE_NAME, project.getName())
@@ -255,6 +268,7 @@ private fun registerApplicationExtensionPointsAndExtensionsFrom() {
 
     registerExtensionPointInRoot(CodeStyleSettingsProvider.EXTENSION_POINT_NAME, KotlinSettingsProvider::class)
     registerExtensionPointInRoot(LanguageCodeStyleSettingsProvider.EP_NAME, KotlinLanguageCodeStyleSettingsProvider::class)
+    registerExtensionPointInRoot(JavaModuleSystem.EP_NAME, JavaModuleSystem::class)
     
     with(Extensions.getRootArea()) {
         getExtensionPoint(EP_ERROR_MSGS).registerExtension(DefaultErrorMessagesJvm())


### PR DESCRIPTION
Enables conversion from java to kotlin. Problem reported here https://youtrack.jetbrains.com/issue/KE-108 but probably does not cover all corner cases.

@zarechenskiy unfortunately I don't know where are tests for this feature in intellj.

I tried on this:
```java
package com.acme;

public class JavaToKotlinConversion {
	private int number = 5;

	public static class InnerClass {
		public int foo() {
			return (new JavaToKotlinConversion()).number;
		}
	}

	public JavaToKotlinConversion() {}
	public JavaToKotlinConversion(int number) {
		this.number = number;
	}

	public int bar(int add) {
		return add + number;
	}
}
```
and got (with compilation error - see below)
```kotlin
package com.acme

class JavaToKotlinConversion {
	private val number = 5

	class InnerClass {
		fun foo(): Int {
			return (JavaToKotlinConversion()).number
		}
	}

	constructor() {}
	constructor(number: Int) {
		this.number = number // <- reassigning to val error
	}

	fun bar(add: Int): Int {
		return add + number
	}
}
```
hope it is ok