### PR TITLE
Fix for run failing with java 9 & 10

### DIFF
--- a/kotlin-eclipse-core/plugin.xml
+++ b/kotlin-eclipse-core/plugin.xml
@@ -45,4 +45,11 @@
          </adapt>
       </definition>
    </extension>
+   <extension
+         point="org.eclipse.jdt.launching.classpathProviders">
+      <classpathProvider
+            class="org.jetbrains.kotlin.core.KotlinClasspathProvider"
+            id="org.jetbrains.kotlin.core.kotlinClasspathProvider">
+      </classpathProvider>
+   </extension>
 </plugin>

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/KotlinClasspathProvider.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/KotlinClasspathProvider.kt
@@ -1,0 +1,20 @@
+package org.jetbrains.kotlin.core
+
+import org.eclipse.debug.core.ILaunchConfiguration
+import org.eclipse.jdt.launching.IRuntimeClasspathEntry
+import org.eclipse.jdt.launching.JavaRuntime
+import org.eclipse.jdt.launching.StandardClasspathProvider
+
+const val KOTLIN_CLASSPATH_PROVIDER_ID = "org.jetbrains.kotlin.core.kotlinClasspathProvider"
+
+class KotlinClasspathProvider : StandardClasspathProvider() {
+    override fun computeUnresolvedClasspath(configuration: ILaunchConfiguration): Array<IRuntimeClasspathEntry> =
+            super.computeUnresolvedClasspath(configuration)
+                    .filterNot { it.location != null && it.location == configuration.lightClassPath }
+                    .toTypedArray()
+
+    private val ILaunchConfiguration.lightClassPath: String?
+        get() = JavaRuntime.getJavaProject(this)
+                ?.let { KotlinClasspathContainer.getPathToLightClassesFolder(it) }
+                ?.toPortableString()
+}

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/launch/KotlinLaunchShortcut.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/ui/launch/KotlinLaunchShortcut.kt
@@ -44,17 +44,21 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.ui.editors.KotlinFileEditor
 import org.eclipse.jdt.core.JavaCore
 import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.core.KOTLIN_CLASSPATH_PROVIDER_ID
+
 
 class KotlinLaunchShortcut : ILaunchShortcut {
     companion object {
         fun createConfiguration(entryPoint: KtDeclaration, project: IProject): ILaunchConfiguration? {
             val classFqName = getStartClassFqName(entryPoint)
             if (classFqName == null) return null
-            
-            val configWC = getLaunchConfigurationType().newInstance(null, "Config - " + entryPoint.getContainingKtFile().getName())
-            configWC.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, classFqName.asString())
-            configWC.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, project.getName())
-            
+
+            val configWC = getLaunchConfigurationType().newInstance(null, "Config - " + entryPoint.getContainingKtFile().getName()).apply {
+                setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, classFqName.asString())
+                setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, project.getName())
+                setAttribute(IJavaLaunchConfigurationConstants.ATTR_CLASSPATH_PROVIDER, KOTLIN_CLASSPATH_PROVIDER_ID)
+            }
+
             return configWC.doSave()
         }
         
@@ -99,9 +103,9 @@ class KotlinLaunchShortcut : ILaunchShortcut {
     }
     
     private fun launchWithMainClass(entryPoint: KtDeclaration, project: IProject, mode: String) {
-        val configuration = findLaunchConfiguration(getLaunchConfigurationType(), entryPoint, project) ?: 
-                createConfiguration(entryPoint, project)
-        
+        val configuration = findLaunchConfiguration(getLaunchConfigurationType(), entryPoint, project)
+                ?: createConfiguration(entryPoint, project)
+
         if (configuration != null) {
             DebugUITools.launch(configuration, mode)
         }


### PR DESCRIPTION
[KE-96](https://youtrack.jetbrains.com/issue/KE-96)

User is now able to build and run kotlin projects using java 9 or 10.