### PR TITLE
Fixes project specific Kotlin compiler preferences

### DIFF
--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/Activator.java
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/Activator.java
@@ -48,8 +48,7 @@ public class Activator extends Plugin {
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(KotlinRefreshProjectListener.INSTANCE,
 		        IResourceChangeEvent.PRE_REFRESH);
 		
-		// Creating property object in default scope assures that values from 'preferences.ini' were loaded.
-		new KotlinProperties(DefaultScope.INSTANCE);
+		KotlinProperties.init();
 	}
 
 	@Override

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/KotlinEnvironment.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/model/KotlinEnvironment.kt
@@ -383,10 +383,10 @@ class KotlinEnvironment private constructor(val eclipseProject: IProject, dispos
         KotlinCommonEnvironment(disposable) {
     val javaProject = JavaCore.create(eclipseProject)
 
-    private val _compilerProperties: KotlinProperties = KotlinProperties(ProjectScope(eclipseProject))
+    val projectCompilerProperties: KotlinProperties = KotlinProperties(ProjectScope(eclipseProject))
 
     val compilerProperties: KotlinProperties
-        get() = _compilerProperties.takeIf { it.globalsOverridden } ?: KotlinProperties.workspaceInstance
+        get() = projectCompilerProperties.takeIf { it.globalsOverridden } ?: KotlinProperties.workspaceInstance
 
     val index by lazy { JvmDependenciesIndexImpl(getRoots().toList()) }
 

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/preferences/KotlinProperties.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/preferences/KotlinProperties.kt
@@ -17,7 +17,14 @@ class KotlinProperties(scope: IScopeContext = InstanceScope.INSTANCE) : Preferen
     var compilerFlags by StringPreference()
 
     companion object {
-        val workspaceInstance = KotlinProperties()
+        // Property object in instance scope (workspace) must be created after one in global scope (see: init())
+        val workspaceInstance by lazy { KotlinProperties() }
+
+        @JvmStatic
+        fun init() {
+            // Creating property object in default scope assures that values from 'preferences.ini' are loaded
+            KotlinProperties(DefaultScope.INSTANCE)
+        }
     }
 }
 

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/preferences/properties/ProjectCompilerPropertyPage.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/preferences/properties/ProjectCompilerPropertyPage.kt
@@ -15,7 +15,7 @@ class ProjectCompilerPropertyPage : KotlinCompilerPropertyPage(), IWorkbenchProp
     // project must be lazy initialized, because getElement() called during construction of page object returns null
     val project: IProject by lazy { element.getAdapter(IProject::class.java) }
 
-    override val kotlinProperties by lazy { KotlinEnvironment.getEnvironment(project).compilerProperties }
+    override val kotlinProperties by lazy { KotlinEnvironment.getEnvironment(project).projectCompilerProperties }
 
     private var overrideFlag by LazyObservable({ kotlinProperties.globalsOverridden }) { _, _, value ->
         kotlinProperties.globalsOverridden = value


### PR DESCRIPTION
I modified project-specific Kotlin compiler preference page, so that it always displays (and modified) project-specific preferences. Previously global preferences could be displayed and modified.

I fixed order in which Kotlin compiler preferences are loaded. Now preferences from default scope (preferences.ini) are loaded first, before ones from instance (workspace) scope. Previously instance scope properties would ignore default scope properties instead of defaulting to them.