### PR TITLE
Annotation support

### DIFF
--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/lang/java/structure/EclipseJavaAnnotationArgument.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/lang/java/structure/EclipseJavaAnnotationArgument.kt
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2000-2014 JetBrains s.r.o.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- *   
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,27 +16,30 @@
  *******************************************************************************/
 package org.jetbrains.kotlin.core.resolve.lang.java.structure
 
-import org.eclipse.jdt.core.dom.IBinding
-import org.jetbrains.kotlin.name.Name
 import org.eclipse.jdt.core.IJavaProject
-import org.jetbrains.kotlin.load.java.structure.JavaAnnotationArgument
 import org.eclipse.jdt.core.dom.IAnnotationBinding
+import org.eclipse.jdt.core.dom.IBinding
+import org.eclipse.jdt.core.dom.ITypeBinding
 import org.eclipse.jdt.core.dom.IVariableBinding
-	
-public abstract class EclipseJavaAnnotationArgument<T : IBinding>(javaElement: T) : 
-	EclipseJavaElement<T>(javaElement), JavaAnnotationArgument {
-	
+import org.jetbrains.kotlin.load.java.structure.JavaAnnotationArgument
+import org.jetbrains.kotlin.name.Name
+
+public abstract class EclipseJavaAnnotationArgument<T : IBinding>(javaElement: T) :
+		EclipseJavaElement<T>(javaElement), JavaAnnotationArgument {
+
 	override val name: Name?
 		get() = Name.identifier(binding.getName())
-	
+
 	companion object {
-		@JvmStatic fun create(value: Any, name: Name, javaProject: IJavaProject): JavaAnnotationArgument {
+		@JvmStatic
+		fun create(value: Any, name: Name, javaProject: IJavaProject): JavaAnnotationArgument {
 			return when (value) {
 				is IAnnotationBinding -> EclipseJavaAnnotationAsAnnotationArgument(value, name)
 				is IVariableBinding -> EclipseJavaReferenceAnnotationArgument(value)
-				is Array<*> -> EclipseJavaArrayAnnotationArgument(value, name, javaProject) 
+				is Array<*> -> EclipseJavaArrayAnnotationArgument(value, name, javaProject)
 				is Class<*> -> EclipseJavaClassObjectAnnotationArgument(value, name, javaProject)
 				is String -> EclipseJavaLiteralAnnotationArgument(value, name)
+				is ITypeBinding -> EclipseJavaTypeAsAnnotationArgument(value, name)
 				else -> throw IllegalArgumentException("Wrong annotation argument: $value")
 			}
 		}

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/lang/java/structure/EclipseJavaField.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/lang/java/structure/EclipseJavaField.kt
@@ -25,8 +25,7 @@ public class EclipseJavaField(private val javaField: IVariableBinding) : Eclipse
     override val hasConstantNotNullInitializer: Boolean
         get() = false
     
-    override val initializerValue: Any?
-        get() = null
+    override val initializerValue: Any? = binding.constantValue
 
     override val isEnumEntry: Boolean = binding.isEnumConstant()
     

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/lang/java/structure/EclipseJavaPropertyInitializerEvaluator.java
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/lang/java/structure/EclipseJavaPropertyInitializerEvaluator.java
@@ -22,12 +22,23 @@ import org.jetbrains.kotlin.descriptors.PropertyDescriptor;
 import org.jetbrains.kotlin.load.java.components.JavaPropertyInitializerEvaluator;
 import org.jetbrains.kotlin.load.java.structure.JavaField;
 import org.jetbrains.kotlin.resolve.constants.ConstantValue;
+import org.jetbrains.kotlin.resolve.constants.ConstantValueFactory;
 
 public class EclipseJavaPropertyInitializerEvaluator implements JavaPropertyInitializerEvaluator {
     @Override
     @Nullable
     public ConstantValue<?> getInitializerConstant(@NotNull JavaField field, @NotNull PropertyDescriptor descriptor) {
-        // TODO Auto-generated method stub
-        return null;
+        Object evaluated = field.getInitializerValue();
+        if (evaluated == null)
+            return null;
+        // Note: evaluated expression may be of class that does not match field type in
+        // some cases
+        // tested for Int, left other checks just in case
+        if (evaluated instanceof Byte || evaluated instanceof Short || evaluated instanceof Integer
+                || evaluated instanceof Long)
+            return ConstantValueFactory.INSTANCE.createIntegerConstantValue(((Number) evaluated).longValue(),
+                    descriptor.getType());
+        else
+            return ConstantValueFactory.INSTANCE.createConstantValue(evaluated);
     }
 }

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/lang/java/structure/EclipseJavaTypeAsAnnotationArgument.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/lang/java/structure/EclipseJavaTypeAsAnnotationArgument.kt
@@ -1,0 +1,17 @@
+package org.jetbrains.kotlin.core.resolve.lang.java.structure
+
+import org.eclipse.jdt.core.dom.ITypeBinding
+import org.jetbrains.kotlin.load.java.structure.JavaEnumValueAnnotationArgument
+import org.jetbrains.kotlin.load.java.structure.JavaType
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.load.java.structure.JavaClassObjectAnnotationArgument
+
+public class EclipseJavaTypeAsAnnotationArgument(binding: ITypeBinding, override val name: Name?)
+	: EclipseJavaAnnotationArgument<ITypeBinding>(binding), JavaClassObjectAnnotationArgument {
+
+	override fun getReferencedType(): JavaType {
+		return EclipseJavaType(binding)
+	}
+}

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/lang/java/structure/EclipseJavaTypeAsAnnotationArgument.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/lang/java/structure/EclipseJavaTypeAsAnnotationArgument.kt
@@ -1,12 +1,9 @@
 package org.jetbrains.kotlin.core.resolve.lang.java.structure
 
 import org.eclipse.jdt.core.dom.ITypeBinding
-import org.jetbrains.kotlin.load.java.structure.JavaEnumValueAnnotationArgument
-import org.jetbrains.kotlin.load.java.structure.JavaType
-import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.load.java.structure.JavaClassObjectAnnotationArgument
+import org.jetbrains.kotlin.load.java.structure.JavaType
+import org.jetbrains.kotlin.name.Name
 
 public class EclipseJavaTypeAsAnnotationArgument(binding: ITypeBinding, override val name: Name?)
 	: EclipseJavaAnnotationArgument<ITypeBinding>(binding), JavaClassObjectAnnotationArgument {

--- a/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/core/tests/diagnostics/AllDiagnosticsTests.java
+++ b/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/core/tests/diagnostics/AllDiagnosticsTests.java
@@ -6,7 +6,8 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses( {
 	KotlinDiagnosticsJavaPlusKotlinTest.class,
-	KotlinDiagnosticsTest.class
+	KotlinDiagnosticsTest.class,
+	JavaAnnotationArgumentsInKotlinTest.class
 } )
 public class AllDiagnosticsTests {
 

--- a/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/core/tests/diagnostics/JavaAnnotationArgumentsInKotlinTest.java
+++ b/kotlin-eclipse-ui-test/src/org/jetbrains/kotlin/core/tests/diagnostics/JavaAnnotationArgumentsInKotlinTest.java
@@ -1,0 +1,25 @@
+package org.jetbrains.kotlin.core.tests.diagnostics;
+
+import org.jetbrains.kotlin.checkers.KotlinDiagnosticsTestCase;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class JavaAnnotationArgumentsInKotlinTest extends KotlinDiagnosticsTestCase {
+    @Override
+    @Before
+    public void configure() {
+        configureProjectWithStdLib();
+    }
+
+    @Test
+    public void testAnnotationAsJavaAnnotationArgument() throws Exception {
+        // KE-266
+        doTest("testData/diagnostics/annotationAsJavaAnnotationArgument.kt");
+    }
+
+    @Test
+    public void testConstAsJavaAnnotationArgument() throws Exception {
+        doTest("testData/diagnostics/constAsJavaAnnotationArgument.kt");
+    }
+}

--- a/kotlin-eclipse-ui-test/testData/diagnostics/annotationAsJavaAnnotationArgument.kt
+++ b/kotlin-eclipse-ui-test/testData/diagnostics/annotationAsJavaAnnotationArgument.kt
@@ -1,0 +1,14 @@
+// FILE: Ann.java
+import java.lang.annotation.Repeatable;
+
+@Repeatable(Anns.class)
+public @interface Ann {}
+
+// FILE: Anns.java
+public @interface Anns {
+    Ann[] value();
+}
+
+// FILE: Aaa.kt
+@Ann
+class Aaa

--- a/kotlin-eclipse-ui-test/testData/diagnostics/constAsJavaAnnotationArgument.kt
+++ b/kotlin-eclipse-ui-test/testData/diagnostics/constAsJavaAnnotationArgument.kt
@@ -1,0 +1,13 @@
+// FILE: Consts.java
+public interface Consts {
+	short value = 5
+}
+
+// FILE: Ann.java
+public @interface Ann {
+	short value();
+}
+
+// FILE: Aaa.kt
+@Ann(Consts.value)
+class Aaa


### PR DESCRIPTION
Supports literals type of Byte, Integer, Short and Long (Previously only String was supported) in
annotation definition.
Adds support for `ITypeBinding` as annotation parameter in eclipse.