### PR TITLE
Adds language version and api version preferences

### DIFF
--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/compiler/KotlinCompiler.java
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/compiler/KotlinCompiler.java
@@ -111,11 +111,8 @@ public class KotlinCompiler {
         command.add("-no-jdk");
         command.add("-no-stdlib"); // Because we add runtime into the classpath
 
-        JvmTarget jvmTarget = kotlinProperties.getJvmTarget();
-        if (jvmTarget != null) {
-            command.add("-jvm-target");
-            command.add(jvmTarget.getDescription());
-        }
+        command.add("-jvm-target");
+        command.add(kotlinProperties.getJvmTarget().getDescription());
 
         command.add("-language-version");
         command.add(kotlinProperties.getLanguageVersion().getVersionString());

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/compiler/KotlinCompiler.java
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/compiler/KotlinCompiler.java
@@ -117,6 +117,12 @@ public class KotlinCompiler {
             command.add(jvmTarget.getDescription());
         }
 
+        command.add("-language-version");
+        command.add(kotlinProperties.getLanguageVersion().getVersionString());
+
+        command.add("-api-version");
+        command.add(kotlinProperties.getApiVersion().getVersionString());
+
         for (CompilerPlugin plugin : kotlinProperties.getCompilerPlugins().getEntries()) {
             command.addAll(configurePlugin(plugin));
         }

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/preferences/KotlinProperties.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/preferences/KotlinProperties.kt
@@ -11,8 +11,9 @@ import org.jetbrains.kotlin.config.LanguageVersion
 
 class KotlinProperties(scope: IScopeContext = InstanceScope.INSTANCE) : Preferences(scope, Activator.PLUGIN_ID) {
     var globalsOverridden by BooleanPreference()
-    
-    var jvmTarget by EnumPreference<JvmTarget>()
+
+    // Note: default value is defined in preferences.ini
+    var jvmTarget by EnumPreference<JvmTarget>(JvmTarget.DEFAULT)
 
     var languageVersion by object : Preference<LanguageVersion> {
         override fun reader(text: String?) = text

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/preferences/KotlinProperties.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/preferences/KotlinProperties.kt
@@ -6,11 +6,32 @@ import org.eclipse.core.runtime.preferences.IScopeContext
 import org.eclipse.core.runtime.preferences.DefaultScope
 import org.osgi.service.prefs.Preferences as InternalPreferences
 import org.eclipse.core.runtime.preferences.InstanceScope
+import org.jetbrains.kotlin.config.ApiVersion
+import org.jetbrains.kotlin.config.LanguageVersion
 
 class KotlinProperties(scope: IScopeContext = InstanceScope.INSTANCE) : Preferences(scope, Activator.PLUGIN_ID) {
     var globalsOverridden by BooleanPreference()
     
     var jvmTarget by EnumPreference<JvmTarget>()
+
+    var languageVersion by object : Preference<LanguageVersion> {
+        override fun reader(text: String?) = text
+                ?.let { LanguageVersion.fromVersionString(it) }
+                ?: LanguageVersion.LATEST_STABLE
+
+        override fun writer(value: LanguageVersion) = value.versionString
+    }
+
+    var apiVersion by object : Preference<ApiVersion> {
+        override fun reader(text: String?): ApiVersion {
+            val apiVersionByLanguageVersion = ApiVersion.createByLanguageVersion(languageVersion)
+            return text?.let { ApiVersion.parse(it) }
+                    ?.takeIf { it <= apiVersionByLanguageVersion }
+                    ?: apiVersionByLanguageVersion
+        }
+
+        override fun writer(value: ApiVersion) = value.versionString
+    }
 
     val compilerPlugins by ChildCollection(::CompilerPlugin)
     

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/preferences/Preferences.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/preferences/Preferences.kt
@@ -1,17 +1,14 @@
 package org.jetbrains.kotlin.core.preferences
 
 import org.eclipse.core.internal.preferences.PreferencesService
-import org.eclipse.core.resources.ProjectScope
 import org.eclipse.core.runtime.preferences.ConfigurationScope
 import org.eclipse.core.runtime.preferences.DefaultScope
 import org.eclipse.core.runtime.preferences.IScopeContext
 import org.eclipse.core.runtime.preferences.InstanceScope
-import org.jetbrains.kotlin.core.log.KotlinLogger
 import kotlin.properties.ReadOnlyProperty
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 import org.osgi.service.prefs.Preferences as Store
-import org.jetbrains.kotlin.core.Activator
 
 private val SCOPES = listOf(InstanceScope.INSTANCE, ConfigurationScope.INSTANCE, DefaultScope.INSTANCE)
 
@@ -37,7 +34,7 @@ abstract class Preferences(private val scope: IScopeContext, private val path: S
                     .firstOrNull { it != null }
 
 
-    private interface Preference<T> : ReadWriteProperty<Preferences, T> {
+    protected interface Preference<T> : ReadWriteProperty<Preferences, T> {
         fun reader(text: String?): T
         fun writer(value: T): String?
 

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/preferences/Preferences.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/preferences/Preferences.kt
@@ -65,10 +65,10 @@ abstract class Preferences(private val scope: IScopeContext, private val path: S
         override fun writer(value: List<String>) = value.joinToString(separator)
     }
 
-    protected inline fun <reified T : Enum<T>> EnumPreference(): ReadWriteProperty<Preferences, T?> =
-            object : Preference<T?> {
-                override fun reader(text: String?) = text?.let { enumValueOf<T>(it) }
-                override fun writer(value: T?) = value?.name
+    protected inline fun <reified T : Enum<T>> EnumPreference(defaultValue: T): ReadWriteProperty<Preferences, T> =
+            object : Preference<T> {
+                override fun reader(text: String?) = text?.let { enumValueOf<T>(it) } ?: defaultValue
+                override fun writer(value: T) = value.name
             }
 
     protected class Child<out T : Preferences>(val factory: (IScopeContext, String) -> T) {

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/EclipseAnalyzerFacadeForJVM.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/EclipseAnalyzerFacadeForJVM.kt
@@ -79,7 +79,7 @@ public object EclipseAnalyzerFacadeForJVM {
         
         val project = environment.project
 
-        val jvmTarget = environment.compilerProperties.jvmTarget ?: JvmTarget.DEFAULT
+        val jvmTarget = environment.compilerProperties.jvmTarget
         
         val moduleContext = createModuleContext(project, environment.configuration, true)
         val storageManager = moduleContext.storageManager

--- a/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/EclipseAnalyzerFacadeForJVM.kt
+++ b/kotlin-eclipse-core/src/org/jetbrains/kotlin/core/resolve/EclipseAnalyzerFacadeForJVM.kt
@@ -92,8 +92,9 @@ public object EclipseAnalyzerFacadeForJVM {
         val moduleClassResolver = SourceOrBinaryModuleClassResolver(sourceScope)
 
         val languageVersionSettings = LanguageVersionSettingsImpl(
-                LanguageVersionSettingsImpl.DEFAULT.languageVersion,
-                LanguageVersionSettingsImpl.DEFAULT.apiVersion)
+                environment.compilerProperties.languageVersion,
+                environment.compilerProperties.apiVersion)
+
         val optionalBuiltInsModule = JvmBuiltIns(storageManager).apply { initialize(module, true) }.builtInsModule
         
         val dependencyModule = run {

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/preferences/KotlinCompilerPropertyPage.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/preferences/KotlinCompilerPropertyPage.kt
@@ -5,11 +5,16 @@ import org.eclipse.core.runtime.IProgressMonitor
 import org.eclipse.core.runtime.IStatus
 import org.eclipse.core.runtime.Status
 import org.eclipse.core.runtime.jobs.Job
+import org.eclipse.jface.resource.FontDescriptor
 import org.eclipse.swt.SWT
 import org.eclipse.swt.widgets.Button
 import org.eclipse.swt.widgets.Composite
+import org.eclipse.swt.widgets.Display
+import org.eclipse.swt.widgets.Label
 import org.eclipse.ui.dialogs.PropertyPage
+import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.config.JvmTarget
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.core.Activator
 import org.jetbrains.kotlin.core.preferences.CompilerPlugin
 import org.jetbrains.kotlin.core.preferences.KotlinProperties
@@ -19,15 +24,33 @@ import org.jetbrains.kotlin.utils.LazyObservable
 abstract class KotlinCompilerPropertyPage : PropertyPage() {
     protected abstract val kotlinProperties: KotlinProperties
 
+    private var languageVersionProxy: LanguageVersion by LazyObservable(
+            initialValueProvider = { kotlinProperties.languageVersion },
+            onChange = { _, _, value ->
+                kotlinProperties.languageVersion = value
+                checkApiVersionCorrectness()
+            }
+    )
+
+    private var apiVersionProxy: ApiVersion by LazyObservable(
+            initialValueProvider = { kotlinProperties.apiVersion },
+            onChange = { _, _, value ->
+                kotlinProperties.apiVersion = value
+                checkApiVersionCorrectness()
+            }
+    )
+
+    private lateinit var apiVersionErrorLabel: Label
+
     private val pluginEntries: Iterable<CompilerPlugin>
         get() = kotlinProperties.compilerPlugins.entries.filterNot(CompilerPlugin::removed)
-    
+
     private var selectedPlugin by LazyObservable<CompilerPlugin?>({ null }) { _, _, value ->
         val editable = value != null
         editButton.enabled = editable
         removeButton.enabled = editable
     }
-    
+
     private lateinit var editButton: View<Button>
 
     private lateinit var removeButton: View<Button>
@@ -40,6 +63,28 @@ abstract class KotlinCompilerPropertyPage : PropertyPage() {
                 enumPreference(kotlinProperties::jvmTarget, nameProvider = JvmTarget::description) {
                     layout(horizontalGrab = true)
                 }
+                label("Language version: ")
+                singleOptionPreference(::languageVersionProxy,
+                        allowedValues = enumValues<LanguageVersion>().asList(),
+                        nameProvider = LanguageVersion::description) {
+                    layout(horizontalGrab = true)
+                }
+                label("API version: ")
+                singleOptionPreference(::apiVersionProxy,
+                        allowedValues = enumValues<LanguageVersion>().map { ApiVersion.createByLanguageVersion(it) },
+                        nameProvider = ApiVersion::description) {
+                    layout(horizontalGrab = true)
+                }
+                label("")
+                apiVersionErrorLabel = label("API version must be lower or equal to language version")
+                        .control
+                        .apply {
+                            font = FontDescriptor.createFrom(control.font)
+                                    .increaseHeight(-1)
+                                    .createFont(Display.getCurrent())
+                            foreground = Display.getCurrent().getSystemColor(SWT.COLOR_RED)
+                            visible = false
+                        }
                 group("Compiler plugins:", cols = 2) {
                     layout(horizontalSpan = 2, verticalGrab = true)
                     val list = checkList(::pluginEntries, selectionDelegate = ::selectedPlugin, style = SWT.BORDER) {
@@ -83,6 +128,12 @@ abstract class KotlinCompilerPropertyPage : PropertyPage() {
         kotlinProperties.flush()
         RebuildJob().schedule()
         return super.performOk()
+    }
+
+    private fun checkApiVersionCorrectness() {
+        val correct = apiVersionProxy <= ApiVersion.createByLanguageVersion(languageVersionProxy)
+        apiVersionErrorLabel.visible = !correct
+        isValid = correct
     }
 
     private inner class RebuildJob : Job("Rebuilding workspace") {

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/preferences/KotlinCompilerPropertyPage.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/preferences/KotlinCompilerPropertyPage.kt
@@ -60,7 +60,9 @@ abstract class KotlinCompilerPropertyPage : PropertyPage() {
     protected fun View<Composite>.createOptionsControls(operations: View<Composite>.() -> Unit = {}) =
             gridContainer(cols = 2) {
                 label("JVM target version: ")
-                enumPreference(kotlinProperties::jvmTarget, nameProvider = JvmTarget::description) {
+                singleOptionPreference(kotlinProperties::jvmTarget,
+                        allowedValues = enumValues<JvmTarget>().asList(),
+                        nameProvider = JvmTarget::description) {
                     layout(horizontalGrab = true)
                 }
                 label("Language version: ")

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/swt/builders/controls.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/swt/builders/controls.kt
@@ -42,10 +42,34 @@ inline fun <reified T : Enum<T>> View<Composite>.enumPreference(
                     ?.let(nameProvider)
                     ?.let(valuesMapping.keys::indexOf)
                     ?.also { select(it) }
- 
+
             addSelectionListener(object : SelectionAdapter() {
                 override fun widgetSelected(event: SelectionEvent) {
                     delegate.set(valuesMapping[(event.widget as Combo).text])
+                }
+            })
+        }.asView.apply(operations)
+                .applyDefaultLayoutIfNeeded()
+
+inline fun <T> View<Composite>.singleOptionPreference(
+        delegate: KMutableProperty0<T>,
+        allowedValues: List<T>,
+        nameProvider: (T) -> String = { it.toString() },
+        style: Int = SWT.NONE,
+        operations: View<Combo>.() -> Unit = {}
+) =
+        Combo(control, style or SWT.READ_ONLY).apply {
+            val valuesMapping = allowedValues.associateByTo(LinkedHashMap(), nameProvider)
+            valuesMapping.keys.forEach { this.add(it) }
+
+            delegate.get()
+                    .let(nameProvider)
+                    .let(valuesMapping.keys::indexOf)
+                    .also { select(it) }
+
+            addSelectionListener(object : SelectionAdapter() {
+                override fun widgetSelected(event: SelectionEvent) {
+                    delegate.set(valuesMapping[(event.widget as Combo).text]!!)
                 }
             })
         }.asView.apply(operations)

--- a/kotlin-eclipse-ui/src/org/jetbrains/kotlin/swt/builders/controls.kt
+++ b/kotlin-eclipse-ui/src/org/jetbrains/kotlin/swt/builders/controls.kt
@@ -27,30 +27,6 @@ inline fun View<Composite>.separator(style: Int = SWT.NONE, operations: View<Lab
                 .apply(operations)
                 .applyDefaultLayoutIfNeeded()
 
-inline fun <reified T : Enum<T>> View<Composite>.enumPreference(
-        delegate: KMutableProperty0<T?>,
-        nameProvider: (T) -> String = { it.toString() },
-        style: Int = SWT.NONE,
-        operations: View<Combo>.() -> Unit = {}
-) =
-        Combo(control, style or SWT.READ_ONLY).apply {
-            val valuesMapping = enumValues<T>()
-                    .associateByTo(LinkedHashMap<String, T?>(), nameProvider)
-            valuesMapping.keys.forEach { add(it) }
-
-            delegate.get()
-                    ?.let(nameProvider)
-                    ?.let(valuesMapping.keys::indexOf)
-                    ?.also { select(it) }
-
-            addSelectionListener(object : SelectionAdapter() {
-                override fun widgetSelected(event: SelectionEvent) {
-                    delegate.set(valuesMapping[(event.widget as Combo).text])
-                }
-            })
-        }.asView.apply(operations)
-                .applyDefaultLayoutIfNeeded()
-
 inline fun <T> View<Composite>.singleOptionPreference(
         delegate: KMutableProperty0<T>,
         allowedValues: List<T>,


### PR DESCRIPTION
I added Kotlin language version and Kotlin API version preferences (visible in workspace properties page and project properties page). They are passed to KotlinCompiler and to EclipseAnalyzerFacadeForJVM.

I also refactored jvmTarget preference and unified enumPreference() with singleOptionPreference().

[KE-94](https://youtrack.jetbrains.com/issue/KE-94)