### PR TITLE
Fixed KE-100: Fixed the Kotlin editor font setting issue

### DIFF
--- a/kotlin-eclipse-ui/plugin.xml
+++ b/kotlin-eclipse-ui/plugin.xml
@@ -237,7 +237,8 @@
             extensions="kt"
             icon="icons/kotlin-file.gif"
             id="org.jetbrains.kotlin.ui.editors.KotlinFileEditor"
-            name="Kotlin Editor">
+            name="Kotlin Editor"
+            symbolicFontName="org.eclipse.jdt.ui.editors.textfont">
       </editor>
       <editor
             class="org.jetbrains.kotlin.ui.editors.KotlinScriptEditor"
@@ -246,7 +247,8 @@
             extensions="kts"
             icon="icons/kotlin-file.gif"
             id="org.jetbrains.kotlin.ui.editors.KotlinScriptEditor"
-            name="Kotlin Script Editor">
+            name="Kotlin Script Editor"
+            symbolicFontName="org.eclipse.jdt.ui.editors.textfont">
       </editor>
       <editor
             class="org.jetbrains.kotlin.ui.editors.KotlinExternalReadOnlyEditor"
@@ -255,7 +257,8 @@
             extensions="kt"
             icon="icons/kotlin-file.gif"
             id="org.jetbrains.kotlin.ui.editors.KotlinExternalReadOnlyEditor"
-            name="Kotlin External Editor">
+            name="Kotlin External Editor"
+            symbolicFontName="org.eclipse.jdt.ui.editors.textfont">
       </editor>
    </extension>
    <extension
@@ -265,7 +268,8 @@
             extensions="class"
             icon="icons/kotlin-file.gif"
             id="org.jetbrains.kotlin.ui.editors.KotlinClassFileEditor"
-            name="Kotlin Class File Editor">
+            name="Kotlin Class File Editor"
+            symbolicFontName="org.eclipse.jdt.ui.editors.textfont">
       </editor>
    </extension>
    <extension


### PR DESCRIPTION
Now the kotlin editors follows the font settings from JDT editor.